### PR TITLE
type: add `UnwrapSangteValue`, `UnwrapSangteAction`

### DIFF
--- a/src/lib/sangte.ts
+++ b/src/lib/sangte.ts
@@ -22,7 +22,9 @@ export type Sangte<T, A extends ActionRecord<T> = any> = {
   config: SangteConfig
 }
 
-export type UnwrapSangteValue<T> = T extends Sangte<infer U> ? U : T
+export type UnwrapSangteValue<T> = T extends Sangte<infer U> ? U : never
+
+export type UnwrapSangteAction<T> = T extends Sangte<any, infer U> ? U : never
 
 function isUpdateFn<T>(value: any): value is UpdateFn<T> {
   return typeof value === 'function'

--- a/src/lib/sangte.ts
+++ b/src/lib/sangte.ts
@@ -22,6 +22,8 @@ export type Sangte<T, A extends ActionRecord<T> = any> = {
   config: SangteConfig
 }
 
+export type UnwrapSangteValue<T> = T extends Sangte<infer U> ? U : T
+
 function isUpdateFn<T>(value: any): value is UpdateFn<T> {
   return typeof value === 'function'
 }


### PR DESCRIPTION
When I use recoil, utility type `UnwrapRecoilValue` is quite useful and I think it's good to have one for `sangte`