### PR TITLE
suggestion: remove passing `undefined` when skip createActions

### DIFF
--- a/src/contexts/__tests__/SangteProvider.test.tsx
+++ b/src/contexts/__tests__/SangteProvider.test.tsx
@@ -102,8 +102,8 @@ describe('SangteProvider', () => {
   })
 
   it('should dehydrate', () => {
-    const counterState = sangte(0, undefined, { key: 'counter' })
-    const textState = sangte('hello world', undefined, { key: 'text' })
+    const counterState = sangte(0, { key: 'counter' })
+    const textState = sangte('hello world', { key: 'text' })
 
     function Child() {
       const counter = useSangteValue(counterState)

--- a/src/lib/__tests__/sangte.test.ts
+++ b/src/lib/__tests__/sangte.test.ts
@@ -90,10 +90,13 @@ describe('sangte', () => {
   })
 
   it('should have config', () => {
-    const create = sangte({ count: 0 }, undefined, {
-      global: true,
-      key: 'counter',
-    })
+    const create = sangte(
+      { count: 0 },
+      {
+        global: true,
+        key: 'counter',
+      }
+    )
     expect(create.config).toEqual({
       global: true,
       key: 'counter',

--- a/src/lib/sangte.ts
+++ b/src/lib/sangte.ts
@@ -93,14 +93,30 @@ function createSangte<T, A extends ActionRecord<T>>(
 
 export function sangte<T, A extends ActionRecord<T>>(
   initialState: T,
-  actions?: Actions<T, A>,
-  config: SangteConfig = {}
+  config?: SangteConfig
+): Sangte<T, A>
+export function sangte<T, A extends ActionRecord<T>>(
+  initialState: T,
+  actions: Actions<T, A>,
+  config?: SangteConfig
+): Sangte<T, A>
+export function sangte<T, A extends ActionRecord<T>>(
+  initialState: T,
+  actions?: Actions<T, A> | SangteConfig,
+  config?: SangteConfig
 ) {
+  const hasActions = typeof actions === 'function'
   const sangte = function () {
-    return createSangte<T, A>(initialState, actions)
+    if (hasActions) {
+      return createSangte<T, A>(initialState, actions)
+    }
+    return createSangte(initialState)
   }
-
-  sangte.config = config
+  if (hasActions) {
+    sangte.config = config || {}
+  } else {
+    sangte.config = actions || {}
+  }
 
   return sangte
 }

--- a/src/samples/Hydration.tsx
+++ b/src/samples/Hydration.tsx
@@ -3,7 +3,7 @@ import { useSangteSelector, useSangteValue } from '../hooks'
 import { useSangte } from '../hooks/useSangte'
 import { sangte } from '../lib/sangte'
 
-const counterSangte = sangte(0, undefined, {
+const counterSangte = sangte(0, {
   key: 'counter',
 })
 
@@ -12,7 +12,6 @@ const userSangte = sangte(
     id: 1,
     username: 'velopert',
   },
-  undefined,
   {
     key: 'user',
   }

--- a/src/samples/Inheritance.tsx
+++ b/src/samples/Inheritance.tsx
@@ -13,7 +13,7 @@ const counterSangte = sangte(0, (prev) => ({
   },
 }))
 
-const textSangte = sangte('', undefined, {
+const textSangte = sangte('', {
   global: true,
 })
 


### PR DESCRIPTION
It would be nicer if I could drop `undefined` when I don't wanna make actions but pass configs!