### PR TITLE
type: throw type Error when accessing actions without createActions

### DIFF
--- a/src/hooks/__tests__/useSangteActions.test.ts
+++ b/src/hooks/__tests__/useSangteActions.test.ts
@@ -40,6 +40,7 @@ describe('useSangteActions', () => {
     expect(() => {
       const {
         result: { current: actions },
+        // @ts-ignore
       } = renderHook(() => useSangteActions(state))
     }).toThrowError()
   })

--- a/src/hooks/__tests__/useSangteCallback.test.ts
+++ b/src/hooks/__tests__/useSangteCallback.test.ts
@@ -63,6 +63,7 @@ describe('useSangteCallback', () => {
 
     const { result } = renderHook(() =>
       useSangteCallback(({ actions }) => {
+        // @ts-ignore
         actions(state)
       }, [])
     )

--- a/src/hooks/useSangteCallback.ts
+++ b/src/hooks/useSangteCallback.ts
@@ -4,7 +4,7 @@ import { ActionRecord, Sangte } from '../lib/sangte'
 
 interface SanteCallbackParams {
   get: <T>(sangte: Sangte<T>) => T
-  set: <T, A extends ActionRecord<T>>(sangte: Sangte<T, A>, value: T) => void
+  set: <T>(sangte: Sangte<T>, value: T) => void
   actions: <T, A extends ActionRecord<T>>(sangte: Sangte<T, A>) => A
 }
 

--- a/src/hooks/useSangteStore.ts
+++ b/src/hooks/useSangteStore.ts
@@ -1,7 +1,7 @@
 import { useSangteManager } from '../contexts/SangteProvider'
-import { ActionRecord, Sangte } from '../lib/sangte'
+import { Sangte } from '../lib/sangte'
 
-export function useSangteStore<T, A extends ActionRecord<T>>(sangte: Sangte<T, A>) {
+export function useSangteStore<T, A>(sangte: Sangte<T, A>) {
   const sangteManager = useSangteManager()
   const store = sangteManager.get(sangte)
   return store

--- a/src/hooks/useSetSangte.ts
+++ b/src/hooks/useSetSangte.ts
@@ -1,4 +1,3 @@
-import { useSangteManager } from '../contexts/SangteProvider'
 import { Sangte } from '../lib/sangte'
 import { useSangteStore } from './useSangteStore'
 

--- a/src/lib/SangteManager.ts
+++ b/src/lib/SangteManager.ts
@@ -1,4 +1,4 @@
-import { ActionRecord, Sangte, SangteInstance } from './sangte'
+import { Sangte, SangteInstance } from './sangte'
 import { SangteInitializer } from './SangteInitializer'
 
 export class SangteManager {
@@ -6,7 +6,7 @@ export class SangteManager {
   public initializer: SangteInitializer = new SangteInitializer(this)
 
   constructor(public isDefault: boolean = false) {}
-  public get<T, A extends ActionRecord<T>>(sangte: Sangte<T, A>): SangteInstance<T, A> {
+  public get<T, A>(sangte: Sangte<T, A>): SangteInstance<T, A> {
     const manager = sangte.config.global ? this.getRootSangteManager() : this
     const instance = manager.instanceMap.get(sangte)
 


### PR DESCRIPTION
At the moment, If sangte created like below `someSangte` without `createActions` as a second parameter, It will throw runtime Error but no type error for IDE.

``` tsx
const someSangte = sangte(0)
function SomeComp () {
  const actions = useSangteActions(someSangte); // throws runtime error here
} 
```

When action is not provided for a `sangte`, `useSangteActions` and `useSangteCallback` throw type error for better DX!
