### PR TITLE
update: roll-up setting for better tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sangte",
   "description": "Sangte is a fancy React state management library.",
   "private": false,
+  "sideEffects": false,
   "version": "0.1.21",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,12 @@ const bundle = (config) => ({
   external: (id) => !/^[./]/.test(id),
 })
 
+const outputConfig = {
+  preserveModules: true,
+  sourcemap: true,
+  dir: 'dist',
+}
+
 export default [
   bundle({
     plugins: [
@@ -18,14 +24,13 @@ export default [
     ],
     output: [
       {
-        file: `${name}.js`,
+        ...outputConfig,
         format: 'cjs',
-        sourcemap: true,
       },
       {
-        file: `${name}.mjs`,
+        ...outputConfig,
         format: 'es',
-        sourcemap: true,
+        entryFileNames: '[name].mjs',
       },
     ],
   }),


### PR DESCRIPTION
Adding `preserveModules: true` to `rollup.config.js` and `sideEffects: false` to `package.json`