### PR TITLE
fix: function overloading for initialState only

### DIFF
--- a/src/lib/sangte.ts
+++ b/src/lib/sangte.ts
@@ -105,6 +105,7 @@ function createSangte<T, A>(initialState: T, createActions?: Actions<T, A>): San
 }
 
 export function sangte<T>(selector: (get: Getter) => T): Sangte<T>
+export function sangte<T>(initialState: T): Sangte<T>
 export function sangte<T, A>(initialState: T, config?: SangteConfig): Sangte<T, A>
 export function sangte<T, A>(
   initialState: T,


### PR DESCRIPTION
There was a type problem with function overloading for `sangte`

```ts
const userState = sangte<User | null>(null)
```

caused error since current function expects selector function only.